### PR TITLE
BuildFixforLockerrorforPpc64le

### DIFF
--- a/src/c/src/mt_adaptor.c
+++ b/src/c/src/mt_adaptor.c
@@ -483,13 +483,7 @@ int32_t inc_ref_counter(zhandle_t* zh,int i)
 int32_t fetch_and_add(volatile int32_t* operand, int incr)
 {
 #ifndef WIN32
-    int32_t result;
-    asm __volatile__(
-         "lock xaddl %0,%1\n"
-         : "=r"(result), "=m"(*(int *)operand)
-         : "0"(incr)
-         : "memory");
-   return result;
+    return __sync_fetch_and_add(operand, incr);
 #else
     volatile int32_t result;
     _asm


### PR DESCRIPTION
Hi, 

While building HDP-zookeeper for HDP 2.5.0 for RHEL-ppc64le, getting build error below:
Error: unrecognized opcode: `lock'

Fix: I have merged part of code for linux specific from commit id:https://github.com/apache/zookeeper/commit/97e598b6c1068624ab6b6a663d3d40047589199a

I have already updated same in wiki.

Thanks & Regards,
Sonali Shrivastava
